### PR TITLE
fix(FEC-11883): Related: System shows the timer when the autoContinue = false

### DIFF
--- a/src/related-manager.ts
+++ b/src/related-manager.ts
@@ -54,7 +54,7 @@ class RelatedManager {
   }
 
   get countdownTime() {
-    return Number.isInteger(this.config.autoContinueTime) ? this.config.autoContinueTime : -1;
+    return this.config.autoContinue && Number.isInteger(this.config.autoContinueTime) ? this.config.autoContinueTime : -1;
   }
 
   get entries() {


### PR DESCRIPTION
### Description of the Changes

If autoContinue is false, return countdownTime -1 which will prevent countdown from showing

Fixes FEC-11883

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
