### PR TITLE
fix(FEC-12032): the name of some media is cut when it is displaying in the grid

### DIFF
--- a/src/components/entry/entry.scss
+++ b/src/components/entry/entry.scss
@@ -8,6 +8,7 @@
 .up-next-text {
   @extend .text;
   color: #ccc;
+  line-height: 18px;
 }
 
 .title-text {
@@ -21,6 +22,10 @@
 /* entry */
 .entry {
   position: relative;
+
+  img {
+    border-radius: 8px 8px 0 0;
+  }
 
   .entry-content {
     background-color: #222;
@@ -36,12 +41,17 @@
 
 /* specific entries */
 .next-entry {
-  img {
-    border-radius: 8px;
-  }
-
   .entry-content {
     padding: 8px 16px 16px;
+
+    .title-text {
+      padding: 4px 0;
+    }
+
+    .entry-text {
+      line-height: 18px;
+      height: 92px;
+    }
   }
 
   .buttons {
@@ -95,18 +105,8 @@
     }
   }
 
-  &.small {
-    img {
-      border-radius: 8px 8px 0 0;
-    }
-  }
-
   &.medium {
     margin-right: 16px;
-
-    img {
-      border-radius: 8px 8px 0 0;
-    }
   }
 
   &.large,
@@ -146,10 +146,6 @@
 
   .entry-text {
     margin: 8px 16px;
-  }
-
-  img {
-    border-radius: 8px;
   }
 }
 

--- a/src/components/entry/next-entry.tsx
+++ b/src/components/entry/next-entry.tsx
@@ -43,7 +43,9 @@ const NextEntry = withText({
           </span>
         </div>
         <div className={styles.titleText}>{props.title}</div>
-        <div className={styles.entryText}>{props.description ? <MultilineText text={props.description} lineHeight={18} lines={2} /> : <></>}</div>
+        <div className={`${styles.entryText} ${styles.text}`}>
+          {props.description ? <MultilineText text={props.description} lineHeight={18} lines={2} /> : <></>}
+        </div>
       </div>
     </BaseNextEntry>
   );

--- a/src/components/multiline-text/multiline-text.scss
+++ b/src/components/multiline-text/multiline-text.scss
@@ -1,0 +1,11 @@
+.multiline-text {
+  word-break: break-word;
+  height: 100%;
+  width: 100%;
+
+  div {
+    height: 100%;
+    width: 100%;
+    line-height: 18px;
+  }
+}

--- a/src/components/multiline-text/multiline-text.tsx
+++ b/src/components/multiline-text/multiline-text.tsx
@@ -1,5 +1,7 @@
 import {useState, useRef, useLayoutEffect, useMemo} from 'preact/hooks';
 
+import * as styles from './multiline-text.scss';
+
 interface MultilineTextProps {
   text: string;
   lineHeight: number;
@@ -45,7 +47,7 @@ const MultilineText = ({text, lineHeight, lines}: MultilineTextProps) => {
   }, [isTextFinalized, cutoffHeight, minLength, text, maxLength, currentLength]);
 
   return (
-    <div>
+    <div className={styles.multilineText}>
       <div ref={ref}>{isTextFinalized ? finalizedText : text.slice(0, currentLength)}</div>
     </div>
   );


### PR DESCRIPTION
### Description of the Changes

Add break-word in case words in entry title or description are too long
Fix missing styles for entry description
Also fixed image border-radius

Resolves FEC-12032

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
