### PR TITLE
fix(FEC-12106): Related Grid shows wrong data after page 2

### DIFF
--- a/src/components/entry/grid-entry.tsx
+++ b/src/components/entry/grid-entry.tsx
@@ -26,6 +26,7 @@ const GridEntry = (props: GridEntryProps) => {
 
   return (
     <div
+      key={id}
       className={`${styles.entry} ${styles.gridEntry} ${styles.clickable}`}
       style={{width, color: KalturaPlayer.ui.style.white}}
       onClick={() => {

--- a/src/components/entry/minimal-grid-entry.tsx
+++ b/src/components/entry/minimal-grid-entry.tsx
@@ -16,6 +16,7 @@ const MinimalGridEntry = (props: GridEntryProps) => {
 
   return (
     <div
+      key={id}
       className={`${styles.entry} ${styles.gridEntry} ${styles.minimal} ${styles.clickable} ${styles.minimal}`}
       style={{width, color: KalturaPlayer.ui.style.white}}
       onClick={() => {

--- a/src/components/related-grid/grid-utils.tsx
+++ b/src/components/related-grid/grid-utils.tsx
@@ -94,7 +94,6 @@ const getPageSize = (sizeBreakpoint: string) => NUM_ENTRIES[sizeBreakpoint];
 const getGridEntry = (sizeBreakpoint: string, data: Sources, entryDimensions: EntryDimensions) => {
   const props = {
     id: data.internalIndex,
-    key: data.internalIndex,
     duration: data.duration,
     type: data.type,
     poster: data.poster,
@@ -108,7 +107,6 @@ const getNextEntry = (sizeBreakpoint: string, countdown: number, data: Sources, 
   const {duration, type, poster, metadata} = data;
   const props = {
     id: 0,
-    key: 0,
     duration,
     type,
     poster,

--- a/src/components/related-grid/related-grid.tsx
+++ b/src/components/related-grid/related-grid.tsx
@@ -52,7 +52,8 @@ const RelatedGrid = connect(mapStateToProps)(({data, countdown, sizeBreakpoint}:
   }, [pageAction]);
   const entriesPerPage = getPageSize(sizeBreakpoint);
   const getEntriesByPage = (page: number) => {
-    return data.slice(page * (entriesPerPage - 1), 1 + (page + 1) * entriesPerPage);
+    const firstPageSize = entriesPerPage - 1;
+    return data.slice(firstPageSize + (page - 1) * entriesPerPage, firstPageSize + page * entriesPerPage);
   };
 
   const arrowLeft =


### PR DESCRIPTION
### Description of the Changes

Fix entry data slice and add key to grid entries which was removed during responsiveness refactor

Resolves FEC-12106

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
