### PR TITLE
fix(FEC-12048): Related - System saves the grid's page after scrolling using pagination

### DIFF
--- a/src/components/related-overlay/related-overlay.scss
+++ b/src/components/related-overlay/related-overlay.scss
@@ -7,12 +7,6 @@
 
   position: absolute;
 
-  &.hidden {
-    opacity: 0;
-    pointer-events: none;
-    cursor: default;
-  }
-
   .related-content {
     display: flex;
     transform: translate(-50%, -50%);

--- a/src/components/related-overlay/related-overlay.tsx
+++ b/src/components/related-overlay/related-overlay.tsx
@@ -50,9 +50,9 @@ const RelatedOverlay = connect(mapStateToProps)(({relatedManager, isPaused, isPl
     setCountdown(relatedManager.countdownTime);
   }
 
-  return (
+  return isVisible ? (
     <div>
-      <div className={`${styles.relatedOverlay} ${isVisible ? '' : styles.hidden}`}>
+      <div className={styles.relatedOverlay}>
         <RelatedContext.Provider value={{relatedManager}}>
           <div className={styles.relatedContent}>
             {sizeBreakpoint === PLAYER_SIZE.EXTRA_SMALL || sizeBreakpoint === PLAYER_SIZE.SMALL ? (
@@ -64,6 +64,8 @@ const RelatedOverlay = connect(mapStateToProps)(({relatedManager, isPaused, isPl
         </RelatedContext.Provider>
       </div>
     </div>
+  ) : (
+    <></>
   );
 });
 


### PR DESCRIPTION
### Description of the Changes

When the overlay is hidden, reset the grid state by returning an empty div instead of returning the grid component 

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
