### PR TITLE
fix(FEC-12119): Related grid responsiveness: Possible to stop player's navigation when width<=279

### DIFF
--- a/src/components/related-overlay/related-overlay.tsx
+++ b/src/components/related-overlay/related-overlay.tsx
@@ -42,11 +42,7 @@ const RelatedOverlay = connect(mapStateToProps)(({relatedManager, isPaused, isPl
     return <></>;
   } else if (!isPlaybackEnded) {
     setIsVisible(
-      isPaused &&
-        relatedManager.showOnPlaybackPaused &&
-        sizeBreakpoint !== PLAYER_SIZE.TINY &&
-        sizeBreakpoint !== PLAYER_SIZE.EXTRA_SMALL &&
-        sizeBreakpoint !== PLAYER_SIZE.SMALL
+      isPaused && relatedManager.showOnPlaybackPaused && ![PLAYER_SIZE.TINY, PLAYER_SIZE.VERY_SMALL, PLAYER_SIZE.SMALL].includes(sizeBreakpoint)
     );
     setCountdown(-1);
   } else {

--- a/src/components/related-overlay/related-overlay.tsx
+++ b/src/components/related-overlay/related-overlay.tsx
@@ -42,7 +42,11 @@ const RelatedOverlay = connect(mapStateToProps)(({relatedManager, isPaused, isPl
     return <></>;
   } else if (!isPlaybackEnded) {
     setIsVisible(
-      isPaused && relatedManager.showOnPlaybackPaused && sizeBreakpoint !== PLAYER_SIZE.EXTRA_SMALL && sizeBreakpoint !== PLAYER_SIZE.SMALL
+      isPaused &&
+        relatedManager.showOnPlaybackPaused &&
+        sizeBreakpoint !== PLAYER_SIZE.TINY &&
+        sizeBreakpoint !== PLAYER_SIZE.EXTRA_SMALL &&
+        sizeBreakpoint !== PLAYER_SIZE.SMALL
     );
     setCountdown(-1);
   } else {


### PR DESCRIPTION
### Description of the Changes

Prevent showing the overlay when size breakpoint is tiny and video is paused

Resolves FEC-12119

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
