### PR TITLE
fix(FEC-12148): Related Grid - Grid background in Safari has no blur effect

### DIFF
--- a/src/components/entry/entry.scss
+++ b/src/components/entry/entry.scss
@@ -60,6 +60,8 @@
     transform: translate(-50%, -50%);
     top: 50%;
     left: 50%;
+    width: -webkit-fit-content;
+    width: -moz-fit-content;
     width: fit-content;
 
     .button {
@@ -86,7 +88,9 @@
 
         &.animated {
           .animation {
+            -webkit-animation-timing-function: linear;
             animation-timing-function: linear;
+            -webkit-animation-name: slide-in;
             animation-name: slide-in;
           }
         }
@@ -151,6 +155,12 @@
 
 .clickable {
   cursor: pointer;
+}
+
+@-webkit-keyframes slide-in {
+  100% {
+    transform: translateX(0%);
+  }
 }
 
 @keyframes slide-in {

--- a/src/components/pre-playback-play-overlay-wrapper/pre-playback-play-overlay-wrapper.scss
+++ b/src/components/pre-playback-play-overlay-wrapper/pre-playback-play-overlay-wrapper.scss
@@ -15,6 +15,7 @@
     button {
       height: 64px;
       width: 64px;
+      -webkit-filter: drop-shadow(0px 0px 8px rgba(0, 0, 0, 0.5));
       filter: drop-shadow(0px 0px 8px rgba(0, 0, 0, 0.5));
       background: transparent;
       border: none;

--- a/src/components/related-grid/related-grid.scss
+++ b/src/components/related-grid/related-grid.scss
@@ -13,9 +13,20 @@
 }
 
 @mixin grid-animation($page-width) {
+  @-webkit-keyframes slide-left {
+    100% {
+      transform: translateX(-$page-width);
+    }
+  }
   @keyframes slide-left {
     100% {
       transform: translateX(-$page-width);
+    }
+  }
+
+  @-webkit-keyframes slide-right {
+    100% {
+      transform: translateX($page-width);
     }
   }
 
@@ -137,12 +148,14 @@ $grid-gap: 16px;
 
   &.slide-right {
     .grid-pages {
+      -webkit-animation: slide-right 0.3s ease forwards;
       animation: slide-right 0.3s ease forwards;
     }
   }
 
   &.slide-left {
     .grid-pages {
+      -webkit-animation: slide-left 0.3s ease forwards;
       animation: slide-left 0.3s ease forwards;
     }
   }

--- a/src/components/related-overlay/related-overlay.scss
+++ b/src/components/related-overlay/related-overlay.scss
@@ -1,4 +1,5 @@
 .related-overlay {
+  -webkit-backdrop-filter: blur(16px);
   backdrop-filter: blur(16px);
   background-color: rgba(0, 0, 0, 0.7);
   height: 100%;


### PR DESCRIPTION
### Description of the Changes

Add missing vendor prefixes to css, including -webkit-backdrop-filter

Resolves FEC-12148

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
