### PR TITLE
fix(FEC-12149): Related Grid - Next button position is wrong in live entries

### DIFF
--- a/src/components/next/next.scss
+++ b/src/components/next/next.scss
@@ -1,3 +1,0 @@
-.next {
-  display: inline-block;
-}

--- a/src/components/next/next.tsx
+++ b/src/components/next/next.tsx
@@ -1,19 +1,13 @@
-const {PrevNext, Tooltip} = KalturaPlayer.ui.components;
+const {PrevNext} = KalturaPlayer.ui.components;
 import {useState, useEffect} from 'preact/hooks';
-
-const {withText} = KalturaPlayer.ui.preacti18n;
-
-import * as styles from './next.scss';
 interface NextProps {
-  next: string;
+  showPreview: boolean;
   onClick: (cb: () => void) => void;
   onLoaded: (cb: (nextEntries: []) => void) => void;
   onUnloaded: (cb: (nextEntries: []) => void) => void;
 }
 
-const Next = withText({
-  next: 'playlist.next'
-})((props: NextProps) => {
+const Next = (props: NextProps) => {
   const [entries, setEntries] = useState([]);
 
   useEffect(() => {
@@ -29,15 +23,7 @@ const Next = withText({
     };
   }, []);
 
-  return entries.length ? (
-    <div className={styles.next}>
-      <Tooltip label={props.next}>
-        <PrevNext type={'next'} item={{sources: entries[0]}} onClick={props.onClick} />
-      </Tooltip>
-    </div>
-  ) : (
-    <></>
-  );
-});
+  return entries.length ? <PrevNext type={'next'} item={{sources: entries[0]}} onClick={props.onClick} showPreview={props.showPreview} /> : <></>;
+};
 
 export {Next};

--- a/src/related.tsx
+++ b/src/related.tsx
@@ -98,14 +98,14 @@ class Related extends KalturaPlayer.core.BasePlugin {
       label: 'kaltura-related-overlay-next',
       presets: PRESETS,
       area: 'OverlayPlaybackControls',
-      get: () => <Next {...nextProps} />
+      get: () => <Next {...{...nextProps, showPreview: false}} />
     });
 
     this.player.ui.addComponent({
       label: 'kaltura-related-bottom-bar-next',
       presets: PRESETS,
       area: 'BottomBarPlaybackControls',
-      get: () => <Next {...nextProps} />
+      get: () => <Next {...{...nextProps, showPreview: true}} />
     });
   }
 


### PR DESCRIPTION
### Description of the Changes

Update next button props following FEC-12154 fix in playkit-ui and pass showPreview prop

Resolves FEC-12149

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
