### PR TITLE
fix(FEC-12138): Related grid responsiveness: New video is started to play after clicking "Play Now" and waiting 1-10s for extSources

### DIFF
--- a/src/components/entry/base-next-entry.tsx
+++ b/src/components/entry/base-next-entry.tsx
@@ -44,8 +44,11 @@ const BaseNextEntry = withText({
     }
   }, [countdown, showButtons]);
 
-  const onPlayNowClick = () => {
+  const onPlayNowClick = (e: MouseEvent) => {
+    e.stopPropagation();
     relatedManager?.playNext();
+    clearTimeout(timeoutId);
+    setTimeoutId(-1);
   };
 
   const onCancelClick = (e: MouseEvent) => {
@@ -59,7 +62,7 @@ const BaseNextEntry = withText({
 
   const onEntryClick = () => {
     if (!(countdown > 0 && showButtons)) {
-      onPlayNowClick();
+      relatedManager?.playNext();
     }
   };
 


### PR DESCRIPTION
### Description of the Changes

When timeout was moved out of countdown component (because now countdown isn't always shown), clear timeout wasn't copied

It was needed to clear the timeout and also add stop propagation to prevent play now click from activating onEntryClick by mistake

Resolves FEC-12138

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
