### PR TITLE
fix(FEC-12142): Related grid responsiveness: Replay icon not displayed with full size after finishing the video -> Cancel

### DIFF
--- a/src/components/pre-playback-play-overlay-wrapper/pre-playback-play-overlay-wrapper.scss
+++ b/src/components/pre-playback-play-overlay-wrapper/pre-playback-play-overlay-wrapper.scss
@@ -11,16 +11,26 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
+    display: flex;
 
     button {
-      height: 64px;
-      width: 64px;
+      padding: 0;
+      margin: 0 19px;
       -webkit-filter: drop-shadow(0px 0px 8px rgba(0, 0, 0, 0.5));
       filter: drop-shadow(0px 0px 8px rgba(0, 0, 0, 0.5));
       background: transparent;
       border: none;
       opacity: 0.8;
       cursor: pointer;
+
+      &:hover {
+        opacity: 1;
+      }
+
+      i {
+        height: 64px;
+        width: 64px;
+      }
     }
   }
 }

--- a/src/components/pre-playback-play-overlay-wrapper/pre-playback-play-overlay-wrapper.tsx
+++ b/src/components/pre-playback-play-overlay-wrapper/pre-playback-play-overlay-wrapper.tsx
@@ -56,16 +56,16 @@ const PrePlaybackPlayOverlayWrapper = withText({
         return (
           <div className={styles.minimalPrePlaybackPlayOverlay}>
             <div className={styles.buttonContainer}>
-              <button className={styles.prePlaybackPlayButton} onClick={() => relatedManager.startOver()}>
-                <Tooltip label={startOver}>
+              <Tooltip label={startOver}>
+                <button className={styles.prePlaybackPlayButton} onClick={() => relatedManager.startOver()}>
                   <Icon type={IconType.StartOver} />
-                </Tooltip>
-              </button>
-              <button className={styles.prePlaybackPlayButton} onClick={() => relatedManager.playNext()}>
-                <Tooltip label={next}>
+                </button>
+              </Tooltip>
+              <Tooltip label={next}>
+                <button className={styles.prePlaybackPlayButton} onClick={() => relatedManager.playNext()}>
                   <Icon type={IconType.Next} />
-                </Tooltip>
-              </button>
+                </button>
+              </Tooltip>
               <div />
             </div>
           </div>


### PR DESCRIPTION
### Description of the Changes

Fix styles of start over and adjust to player ui style

Resolves FEC-12142

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
