### PR TITLE
fix(FEC-12184): Related grid responsiveness: New video is started to play after choosing any video from finished and waiting 1-10s for Context

### DIFF
--- a/src/components/entry/base-next-entry.tsx
+++ b/src/components/entry/base-next-entry.tsx
@@ -30,33 +30,24 @@ const BaseNextEntry = withText({
 
   const [animated, setAnimated] = useState(false);
   const [showButtons, setShowButtons] = useState(true);
-  const [timeoutId, setTimeoutId] = useState(-1);
 
   useEffect(() => {
     if (countdown > 0 && showButtons) {
       setAnimated(true);
-      setTimeoutId(
-        window.setTimeout(() => {
-          relatedManager?.playNext();
-          setAnimated(false);
-        }, countdown * 1000)
-      );
+      relatedManager?.playNext(countdown);
     }
   }, [countdown, showButtons]);
 
   const onPlayNowClick = (e: MouseEvent) => {
     e.stopPropagation();
     relatedManager?.playNext();
-    clearTimeout(timeoutId);
-    setTimeoutId(-1);
   };
 
   const onCancelClick = (e: MouseEvent) => {
     e.stopPropagation();
     setAnimated(false);
     setShowButtons(false);
-    clearTimeout(timeoutId);
-    setTimeoutId(-1);
+    relatedManager?.clearNextEntryTimeout();
     onCancel();
   };
 

--- a/src/related-manager.ts
+++ b/src/related-manager.ts
@@ -13,6 +13,7 @@ class RelatedManager extends KalturaPlayer.core.FakeEventTarget {
   private _isHiddenByUser = false;
   private plugin: Related;
   private mediaInfoMap: Map<string, KalturaPlayerTypes.MediaInfo> = new Map();
+  private nextEntryTimeoutId = -1;
 
   constructor(plugin: Related) {
     super();
@@ -88,14 +89,28 @@ class RelatedManager extends KalturaPlayer.core.FakeEventTarget {
     this.plugin.player.play();
   }
 
-  playNext() {
+  playNext(seconds?: number) {
     this.logger.info('going to play next entry');
-    this.playByIndex(0);
+    this.clearNextEntryTimeout();
+
+    if (seconds && seconds > 0) {
+      this.nextEntryTimeoutId = window.setTimeout(() => {
+        this.playByIndex(0);
+      }, seconds * 1000);
+    } else {
+      this.playByIndex(0);
+    }
   }
 
   playSelected(internalIndex: number) {
     this.logger.info('going to play selected entry');
+    this.clearNextEntryTimeout();
     this.playByIndex(internalIndex);
+  }
+
+  clearNextEntryTimeout() {
+    window.clearTimeout(this.nextEntryTimeoutId);
+    this.nextEntryTimeoutId = -1;
   }
 
   listen(name: string, listener: any) {

--- a/src/related-manager.ts
+++ b/src/related-manager.ts
@@ -94,6 +94,7 @@ class RelatedManager extends KalturaPlayer.core.FakeEventTarget {
     this.logger.info('going to play next entry');
 
     if (seconds && seconds > 0) {
+      this.clearNextEntryTimeout();
       this.nextEntryTimeoutId = window.setTimeout(() => {
         this.playByIndex(0);
       }, seconds * 1000);

--- a/src/related-manager.ts
+++ b/src/related-manager.ts
@@ -30,6 +30,7 @@ class RelatedManager extends KalturaPlayer.core.FakeEventTarget {
   }
 
   private playByIndex(index: number) {
+    this.clearNextEntryTimeout();
     this.isHiddenByUser = false;
     if (this.entryService.isPlayable(this.entries[index])) {
       this.plugin.player.setMedia({sources: this.entries[index]});
@@ -91,7 +92,6 @@ class RelatedManager extends KalturaPlayer.core.FakeEventTarget {
 
   playNext(seconds?: number) {
     this.logger.info('going to play next entry');
-    this.clearNextEntryTimeout();
 
     if (seconds && seconds > 0) {
       this.nextEntryTimeoutId = window.setTimeout(() => {
@@ -104,12 +104,11 @@ class RelatedManager extends KalturaPlayer.core.FakeEventTarget {
 
   playSelected(internalIndex: number) {
     this.logger.info('going to play selected entry');
-    this.clearNextEntryTimeout();
     this.playByIndex(internalIndex);
   }
 
   clearNextEntryTimeout() {
-    window.clearTimeout(this.nextEntryTimeoutId);
+    clearTimeout(this.nextEntryTimeoutId);
     this.nextEntryTimeoutId = -1;
   }
 


### PR DESCRIPTION
### Description of the Changes

Refactor countdown timeout to allow clearing it when a grid entry is clicked

Resolves FEC-12184

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
