### PR TITLE
fix(FEC-12234): Related grid accessibility: Pressing of the "Enter" and "Space" keys don't open a chosen video after tabulation

### DIFF
--- a/src/components/entry/base-next-entry.tsx
+++ b/src/components/entry/base-next-entry.tsx
@@ -63,7 +63,12 @@ const BaseNextEntry = withText({
       className={`${styles.entry} ${styles.nextEntry} ${sizeClass}`}
       style={{width, color: KalturaPlayer.ui.style.white, 'line-height': 'normal'}}
       disabled={alwaysShowButtons || (countdown > 0 && showButtons)}
-      onClick={onEntryClick}>
+      onClick={onEntryClick}
+      onKeyDown={({keyCode}: {keyCode: number}) => {
+        if (keyCode === 13 || keyCode === 32) {
+          onEntryClick();
+        }
+      }}>
       <EntryImage {...{poster, duration, type, width, height: imageHeight}}>
         {alwaysShowButtons || (countdown > 0 && showButtons) ? (
           <div className={styles.buttons}>

--- a/src/components/entry/grid-entry.tsx
+++ b/src/components/entry/grid-entry.tsx
@@ -41,6 +41,11 @@ const GridEntry = withText({
       aria-label={`${title} ${liveOrDurationText}`}
       onClick={() => {
         relatedManager?.playSelected(id);
+      }}
+      onKeyDown={({keyCode}: {keyCode: number}) => {
+        if (keyCode === 13 || keyCode === 32) {
+          relatedManager?.playSelected(id);
+        }
       }}>
       <EntryImage {...{poster, duration, type, width, height: imageHeight}} />
       <div className={styles.entryContent} style={{width, height: contentHeight}}>

--- a/src/components/entry/minimal-grid-entry.tsx
+++ b/src/components/entry/minimal-grid-entry.tsx
@@ -29,6 +29,11 @@ const MinimalGridEntry = withText({
       aria-label={`${title} ${liveOrDurationText}`}
       onClick={() => {
         relatedManager?.playSelected(id);
+      }}
+      onKeyDown={({keyCode}: {keyCode: number}) => {
+        if (keyCode === 13 || keyCode === 32) {
+          relatedManager?.playSelected(id);
+        }
       }}>
       <EntryImage {...{poster, duration, type, width: width / 2 - 10, height: imageHeight}} />
       <div className={styles.entryContent} style={{width: width / 2 + 10, height: contentHeight}}>


### PR DESCRIPTION
### Description of the Changes

Entries were changed from buttons to anchor tags since having the screen reader describe them as "links" instead of "buttons" seems more intuitive. 
however anchor tags don't have a default keydown handler like buttons, so it has to be added explicitly

Resolves FEC-12234

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
