### PR TITLE
fix(FEC-12240): Related Entries - Next entry width is wrong in IE11

### DIFF
--- a/src/components/entry/entry.scss
+++ b/src/components/entry/entry.scss
@@ -50,6 +50,8 @@ button {
 
 /* specific entries */
 .next-entry {
+   flex-shrink: 0;
+
   .entry-content {
     padding: 8px 16px 16px;
 


### PR DESCRIPTION
### Description of the Changes

flex-basis (default width) is auto (identical to width) by default, but IE11 ignores that a value of auto for that property
so as a workaround we set flex-shrink to 0 to prevent next entry width from shrinking

Resolves FEC-12240

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
