### PR TITLE
fix(FEC-12241): Related Entries - Grid is centered incorrectly in IE11

### DIFF
--- a/src/components/related-overlay/related-overlay.scss
+++ b/src/components/related-overlay/related-overlay.scss
@@ -9,7 +9,6 @@
   position: absolute;
 
   .related-content {
-    display: flex;
     transform: translate(-50%, -50%);
 
     position: absolute;


### PR DESCRIPTION
### Description of the Changes

removed flex style from overlay (that wasn't actually used because of absolute positioning) which caused IE11 to position the grid incorrectly

Resolves FEC-12241

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
