### PR TITLE
fix(FEC-12242): Related Entries - Play Now button in IE has incorrect style, dimensions and position

### DIFF
--- a/src/components/entry/entry.scss
+++ b/src/components/entry/entry.scss
@@ -1,5 +1,5 @@
 button {
-  all: unset;
+  border: 0;
   cursor: pointer;
 
   &:disabled {
@@ -71,14 +71,15 @@ button {
     transform: translate(-50%, -50%);
     top: 50%;
     left: 50%;
-    width: -webkit-fit-content;
-    width: -moz-fit-content;
-    width: fit-content;
+    width: calc(100% - 8px);
+    justify-content: center;
 
     button {
-      margin: auto;
       border-radius: 4px;
       padding: 4px;
+      width: -webkit-max-content;
+      width: -moz-max-content;
+      width: max-content;
 
       &.play-now {
         display: inline-block;
@@ -108,6 +109,7 @@ button {
 
       &.cancel {
         background-color: rgba($color: #000, $alpha: 0.6);
+        flex-shrink: 0;
       }
 
       .button-text {
@@ -115,6 +117,9 @@ button {
         font-size: 13px;
         font-weight: bold;
         line-height: 15.6px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
     }
   }


### PR DESCRIPTION
### Description of the Changes

IE11 ignores some of the css styles used for buttons, so they had to be reworked with other styles instead

Resolves FEC-12242

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
