### PR TITLE
fix(FEC-12822): Related videos in the kitchen sink panel on top or on the bottom should be responsive

### DIFF
--- a/src/components/entry-image/entry-image.tsx
+++ b/src/components/entry-image/entry-image.tsx
@@ -9,8 +9,6 @@ interface EntryImageProps {
   poster?: string;
   type: KalturaPlayerTypes.EntryTypes;
   duration?: number;
-  width: number;
-  height: number;
   children?: ComponentChildren;
 }
 
@@ -21,17 +19,15 @@ interface EntryImageProps {
  * @param {string} props.poster Entry thumbnail url.
  * @param {string} props.type Entry type.
  * @param {number} props.duration Entry playback duration.
- * @param {number} props.width Image width.
- * @param {number} props.height Image height.
  * @param {object} props.children Child components.
  */
 
-const EntryImage = ({poster, type, duration, width, height, children}: EntryImageProps) => {
+const EntryImage = ({poster, type, duration, children}: EntryImageProps) => {
   return (
-    <div className={styles.entryImage} style={{height}}>
+    <div className={styles.entryImage}>
       {children}
-      <div className={styles.thumbnail}>
-        <Thumbnail poster={poster} width={width} height={height} />
+      <div className={styles.thumbnailWrapper}>
+        <Thumbnail poster={poster} />
       </div>
       <div className={styles.duration}>
         <DurationLabel type={type} duration={duration} />

--- a/src/components/entry-image/entry-image.tsx
+++ b/src/components/entry-image/entry-image.tsx
@@ -9,6 +9,8 @@ interface EntryImageProps {
   poster?: string;
   type: KalturaPlayerTypes.EntryTypes;
   duration?: number;
+  height?: number;
+  width?: number;
   children?: ComponentChildren;
 }
 
@@ -19,14 +21,16 @@ interface EntryImageProps {
  * @param {string} props.poster Entry thumbnail url.
  * @param {string} props.type Entry type.
  * @param {number} props.duration Entry playback duration.
+ * @param {number} props.height Entry image height.
+ * @param {number} props.width Entry image width.
  * @param {object} props.children Child components.
  */
 
-const EntryImage = ({poster, type, duration, children}: EntryImageProps) => {
+const EntryImage = ({poster, type, duration, height, width, children}: EntryImageProps) => {
   return (
     <div className={styles.entryImage}>
       {children}
-      <div className={styles.thumbnailWrapper}>
+      <div style={{height: height || '', width: width || ''}} className={styles.thumbnailWrapper}>
         <Thumbnail poster={poster} />
       </div>
       <div className={styles.duration}>

--- a/src/components/entry/entry.scss
+++ b/src/components/entry/entry.scss
@@ -222,23 +222,45 @@ button {
   align-items: center;
   background-color: transparent;
   border-radius: 4px;
-  display: flex;
-  height: fit-content;
   padding: 8px;
   position: relative;
-
+  
+  .entry-content {
+    background-color: transparent;
+    width: 100%;
+  }
+  
+  .thumbnail-wrapper * {
+    border-radius: 4px;
+  }
+  
   &.horizontal {
-    flex-direction: column;
+    height: 100%;
 
+    .entry-image {
+      height: calc(100% - 35px);
+    }
+
+    .thumbnail-wrapper {
+      height: 100%;
+    }
+    
     .entry-content {
       margin-top: 4px;
       height: 35px;
     }
   }
-
+  
   &.vertical {
+    display: flex;
     flex-direction: row;
+    height: fit-content;
     margin-right: 8px;
+
+    .thumbnail-wrapper {
+      height: 56px;
+      width: 99px;
+    }
 
     .entry-content {
       margin-left: 8px;
@@ -266,10 +288,6 @@ button {
         margin-left: 16px;
       }
 
-      .entry-image {
-        height: 56px;
-        width: 99px;
-      }
     }
 
     .entry-image {
@@ -301,16 +319,6 @@ button {
 
     .entry-content {
       background-color: transparent;
-    }
-  }
-
-  .entry-content {
-    background-color: transparent;
-  }
-
-  .entry-image {
-    .thumbnail * {
-      border-radius: 4px;
     }
   }
 }

--- a/src/components/entry/entry.scss
+++ b/src/components/entry/entry.scss
@@ -65,7 +65,7 @@ button {
 .entry-image {
   position: relative;
 
-  .thumbnail * {
+  .thumbnail-wrapper * {
     border-radius: 8px 8px 0 0;
   }
 
@@ -273,13 +273,8 @@ button {
     }
 
     &.horizontal {
-      .entry-content {
-        margin-left: -16px;
-      }
-
-      .entry-image {
-        height: 90px;
-        width: 160px;
+      .entry-image * {
+        visibility: hidden;
       }
     }
 
@@ -305,10 +300,10 @@ button {
 
         &:first-child {
           margin-bottom: 10px;
-          width: 145px;
+          width: 100%;
         }
         &:nth-child(2) {
-          width: 75px;
+          width: 51.7%;
         }
       }
     }

--- a/src/components/entry/list-entry-placeholder.tsx
+++ b/src/components/entry/list-entry-placeholder.tsx
@@ -1,3 +1,4 @@
+import {Thumbnail} from 'components';
 import * as styles from './entry.scss';
 
 /**
@@ -10,7 +11,9 @@ import * as styles from './entry.scss';
 const ListEntryPlaceholder = ({isVertical}: {isVertical: boolean}) => {
   return (
     <div className={`${styles.listEntry} ${styles.placeholder} ${isVertical ? styles.vertical : styles.horizontal}`}>
-      <div className={styles.entryImage} />
+      <div className={styles.entryImage}>
+        <Thumbnail />
+      </div>
       <div className={styles.entryContent}>
         <div className={styles.textPlaceholder} />
         <div className={styles.textPlaceholder} />

--- a/src/components/entry/list-entry.tsx
+++ b/src/components/entry/list-entry.tsx
@@ -12,11 +12,6 @@ interface ListEntryProps extends GridEntryProps {
   isVertical: boolean;
 }
 
-const VERTICAL_IMAGE_WIDTH = 99;
-const HORIZONTAL_IMAGE_WIDTH = 160;
-const VERTICAL_IMAGE_HEIGHT = 56;
-const HORITONTAL_IMAGE_HEIGHT = 90;
-
 /**
  * List entry with image and title.
  *
@@ -26,7 +21,6 @@ const HORITONTAL_IMAGE_HEIGHT = 90;
  * @param {number} props.duration Entry duration.
  * @param {string} props.type Entry type.
  * @param {string} props.poster Entry poster.
- * @param {object} props.entryDimensions Dimensions for entry render.
  * @param {string} props.live Live label.
  * @param {boolean} props.isVertical If true, indicates that the list entry is vertical, if false indicates that it's horizontal.
  */
@@ -56,9 +50,7 @@ const ListEntry = withText({
         {...{
           poster,
           duration,
-          type,
-          width: isVertical ? VERTICAL_IMAGE_WIDTH : HORIZONTAL_IMAGE_WIDTH,
-          height: isVertical ? VERTICAL_IMAGE_HEIGHT : HORITONTAL_IMAGE_HEIGHT
+          type
         }}
       />
       <div className={styles.entryContent}>

--- a/src/components/multiline-text/multiline-text.scss
+++ b/src/components/multiline-text/multiline-text.scss
@@ -1,7 +1,11 @@
 .multiline-text {
-  word-break: break-word;
+  -webkit-box-orient: vertical;  
+  display: -webkit-box;
   height: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
   width: 100%;
+  word-break: break-word;
 
   div {
     height: 100%;

--- a/src/components/multiline-text/multiline-text.tsx
+++ b/src/components/multiline-text/multiline-text.tsx
@@ -52,7 +52,7 @@ const MultilineText = ({text, lineHeight, lines}: MultilineTextProps) => {
   }, [isTextFinalized, cutoffHeight, minLength, text, maxLength, currentLength]);
 
   return (
-    <div className={styles.multilineText}>
+    <div style={{'-webkit-line-clamp': lines}} className={styles.multilineText}>
       <div ref={ref}>{isTextFinalized ? finalizedText : text.slice(0, currentLength)}</div>
     </div>
   );

--- a/src/components/multiline-text/multiline-text.tsx
+++ b/src/components/multiline-text/multiline-text.tsx
@@ -43,7 +43,7 @@ const MultilineText = ({text, lineHeight, lines}: MultilineTextProps) => {
       setIsTextFinalized(true);
     } else if (minLength >= maxLength) {
       // this is the longest text that can fit within the line limit
-      setFinalizedText(`${text.slice(0, maxLength - 5)}...`);
+      setFinalizedText(`${text.slice(0, maxLength)}`);
       setIsTextFinalized(true);
     } else {
       // test again with a longer text

--- a/src/components/related-countdown-preview/related-countdown-preview.tsx
+++ b/src/components/related-countdown-preview/related-countdown-preview.tsx
@@ -62,7 +62,7 @@ const RelatedCountdownPreview = withText({
       return (
         <RelatedContext.Provider value={{relatedManager}}>
           <div className={`${styles.relatedCountdownPreview} ${isMinimal ? styles.minimal : ''}`} onClick={() => relatedManager.playNext()}>
-            {isMinimal ? <></> : <Thumbnail poster={relatedManager.entries[1]?.poster} width={128} height={72} />}
+            {isMinimal ? <></> : <Thumbnail poster={relatedManager.entries[1]?.poster} />}
             <div className={styles.content}>
               <div className={styles.header}>
                 <span>

--- a/src/components/thumbnail/thumbnail.scss
+++ b/src/components/thumbnail/thumbnail.scss
@@ -2,6 +2,7 @@
   background-color: #000;
   background-size: cover;
   height: 100%;
+  width: fit-content;
 
   img {
     height: 100%;

--- a/src/components/thumbnail/thumbnail.scss
+++ b/src/components/thumbnail/thumbnail.scss
@@ -1,3 +1,11 @@
-.no-image {
+.thumbnail {
   background-color: #000;
+  background-size: cover;
+  height: 100%;
+
+  img {
+    height: 100%;
+    visibility: hidden;
+    width: auto;
+  }
 }

--- a/src/components/thumbnail/thumbnail.tsx
+++ b/src/components/thumbnail/thumbnail.tsx
@@ -2,24 +2,30 @@ import {RelatedContext} from 'components';
 import {useState, useEffect, useContext} from 'preact/hooks';
 import * as styles from './thumbnail.scss';
 
+const DUMMY_IMG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAASCAYAAAA6yNxSAAAAJklEQVR42u3OMQEAAAgDoJnc6BpjDyRgLrcpGgEBAQEBAQGBduABaVYs3Q5APwQAAAAASUVORK5CYII=';
+
 /**
  * Image with fixed dimensions and a fallback option for images which failed to load.
  *
  * @param {object} props Component props.
  * @param {string} props.poster Base image url.
- * @param {number} props.width Image width.
- * @param {number} props.height Image height.
  */
 
-const Thumbnail = ({poster = '', width, height}: {poster?: string; width: number; height: number}) => {
+const Thumbnail = ({poster = ''}: {poster?: string}) => {
   const {relatedManager} = useContext(RelatedContext);
   const [src, setSrc] = useState('');
 
   useEffect(() => {
     relatedManager?.getImageUrl(poster).then((imageUrl: string | null) => setSrc(imageUrl || ''));
-  }, [relatedManager, poster, width, height]);
+  }, [relatedManager, poster]);
 
-  return src ? <img src={src} style={{width, height}} alt="" /> : <div className={styles.noImage} style={{width, height}} />;
+  // use a hidden image so that even blank entries would have dimensions
+  return (
+    <div style={{backgroundImage: `url('${src}')`}} className={styles.thumbnail}>
+      <img src={`${DUMMY_IMG}`} />
+    </div>
+  );
 };
 
 export {Thumbnail};

--- a/src/services/image-service.ts
+++ b/src/services/image-service.ts
@@ -3,8 +3,8 @@ enum IMAGE_STATE {
   NOT_FOUND
 }
 
-const MAX_WIDTH = 260;
-const MAX_HEIGHT = 147;
+const MAX_WIDTH = 400;
+const MAX_HEIGHT = 225;
 
 class ImageService {
   private imageStateMap = new Map<string, IMAGE_STATE>();


### PR DESCRIPTION
### Description of the Changes

Allow entry images to either have explicit dimensions or to adjust to the container height while keeping the 16:9 ratio.

Resolves FEC-12822

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
