### PR TITLE
fix(FEC-12869): Related - Related plugin blocks "up next in" for playlist

### DIFF
--- a/src/related.tsx
+++ b/src/related.tsx
@@ -142,14 +142,6 @@ class Related extends KalturaPlayer.core.BasePlugin {
       area: 'BottomBarPlaybackControls',
       get: () => <Next {...{showPreview: true, onClick: () => relatedManager.playNext(), relatedManager, eventContext: relatedManager}} />
     });
-
-    this.player.ui.addComponent({
-      label: 'kaltura-related-preview',
-      presets: PRESETS,
-      area: 'InteractiveArea',
-      replaceComponent: 'PlaylistCountdown',
-      get: () => <RelatedCountdownPreview {...{relatedManager, eventContext: relatedManager}} />
-    });
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

Fix for reopen - remove duplicate code which caused related preview panel to be added twice.

Resolves FEC-12869

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
