### PR TITLE
fix(FEC-12884): Related Plugin Playing wrong Videos

### DIFF
--- a/src/related-manager.ts
+++ b/src/related-manager.ts
@@ -141,7 +141,13 @@ class RelatedManager extends KalturaPlayer.core.FakeEventTarget {
   private cycleEntries(lastPlayedIndex: number) {
     const lastPlayedEntry = this._entries[lastPlayedIndex];
     this._entries.splice(lastPlayedIndex, 1);
-    this.entries = [...this._entries, lastPlayedEntry];
+
+    this.entries = [...this._entries, lastPlayedEntry].map((entry, index) => {
+      return {
+        ...entry,
+        internalIndex: index
+      };
+    });
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

When the user selects an entry from the list/grid, the entry is cycled to the end of the array of related entries.
However, internalIndex - which is used as the unique identifier of the entry for render - wasn't updated during this reorder, and this caused the display to not be updated.
The solution is to update internalIndex on every reorder of the array.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
