### PR TITLE
fix(FEC-12937): when the related overlay is displayed the minimized video of the dual screen is on top of the overly and it should be below

### DIFF
--- a/src/components/related-overlay/related-overlay.scss
+++ b/src/components/related-overlay/related-overlay.scss
@@ -5,6 +5,7 @@
   height: 100%;
   transition: opacity 0.3s ease;
   width: 100%;
+  z-index: 1;
 
   position: absolute;
 


### PR DESCRIPTION
### Description of the Changes
resolves: https://kaltura.atlassian.net/browse/FEC-12937

fix relative layout if dual-screen active

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
