### PR TITLE
fix(FEC-13517): Wrong and inconsistent order of plugins

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {Related} from './related';
+import { pluginName, Related } from "./related";
 
 declare let __VERSION__: string;
 declare let __NAME__: string;
@@ -8,7 +8,5 @@ const NAME = __NAME__;
 
 export {Related as Plugin};
 export {VERSION, NAME};
-
-export const pluginName = 'related';
 
 KalturaPlayer.core.registerPlugin(pluginName, Related);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { pluginName, Related } from "./related";
+import { pluginName, Related } from './related';
 
 declare let __VERSION__: string;
 declare let __NAME__: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { pluginName, Related } from './related';
+import {pluginName, Related} from './related';
 
 declare let __VERSION__: string;
 declare let __NAME__: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,6 @@ const NAME = __NAME__;
 export {Related as Plugin};
 export {VERSION, NAME};
 
-const pluginName = 'related';
+export const pluginName = 'related';
 
 KalturaPlayer.core.registerPlugin(pluginName, Related);

--- a/src/related.tsx
+++ b/src/related.tsx
@@ -7,6 +7,7 @@ import {UpperBarManager, SidePanelsManager} from '@playkit-js/ui-managers';
 
 import {Icon, RelatedConfig} from 'types';
 import {RelatedInternalEvent} from 'event';
+import { pluginName } from "./index";
 
 const PRESETS = ['Playback', 'Live'];
 
@@ -178,9 +179,14 @@ class Related extends KalturaPlayer.core.BasePlugin {
   addRelatedListComponents() {
     const {relatedManager} = this;
     if (this.iconId > 0 || !relatedManager.entries.length) return;
-
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     this.iconId = this.upperBarManager.add({
-      label: 'Related',
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      displayName: 'Related',
+      ariaLabel: 'Related',
+      order: 60,
       svgIcon: {
         viewBox: '0 0 32 32',
         path: Icon.LIST_TOGGLE

--- a/src/related.tsx
+++ b/src/related.tsx
@@ -7,7 +7,8 @@ import {UpperBarManager, SidePanelsManager} from '@playkit-js/ui-managers';
 
 import {Icon, RelatedConfig} from 'types';
 import {RelatedInternalEvent} from 'event';
-import { pluginName } from "./index";
+
+export const pluginName = 'related';
 
 const PRESETS = ['Playback', 'Live'];
 


### PR DESCRIPTION
### Description of the Changes


**fix: Wrong and inconsistent order of plugins**

**fix: Plugins buttons sometimes display with the wrong icon**

**solves: [FEC-13517](https://kaltura.atlassian.net/browse/FEC-13517) [FEC-13517](https://kaltura.atlassian.net/browse/FEC-13517)**

[FEC-13517]: https://kaltura.atlassian.net/browse/FEC-13517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FEC-13517]: https://kaltura.atlassian.net/browse/FEC-13517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

#### Related Prs
https://github.com/kaltura/playkit-js-ui-managers/pull/51
https://github.com/kaltura/playkit-js-transcript/pull/175
https://github.com/kaltura/playkit-js-share/pull/38
https://github.com/kaltura/playkit-js-moderation/pull/74
https://github.com/kaltura/playkit-js-playlist/pull/53
https://github.com/kaltura/playkit-js-navigation/pull/348
https://github.com/kaltura/playkit-js-info/pull/90
https://github.com/kaltura/playkit-js-navigation/pull/348
https://github.com/kaltura/playkit-js-downloads/pull/39
https://github.com/kaltura/playkit-js-qna/pull/334
