### PR TITLE
fix(FEC-14031): RELATED_CLOSE is being sent upon every entry change in playlist

### DIFF
--- a/src/components/related-list/related-list.tsx
+++ b/src/components/related-list/related-list.tsx
@@ -54,7 +54,7 @@ const RelatedList = withText({
           <div className={styles.title}>{relatedVideosText}</div>
           <CloseButton
             onClick={() => {
-              relatedManager.isListVisible = false;
+              relatedManager.updateListVisibility(false, true);
             }}
           />
         </div>

--- a/src/related-manager.ts
+++ b/src/related-manager.ts
@@ -416,13 +416,15 @@ class RelatedManager extends KalturaPlayer.core.FakeEventTarget {
    *
    * @memberof RelatedManager
    */
-  set isListVisible(isListVisible: boolean) {
+  updateListVisibility(isListVisible: boolean, userInteraction = false) {
     this._isListVisible = isListVisible;
-    this.dispatchEvent(new KalturaPlayer.core.FakeEvent(RelatedInternalEvent.LIST_VISIBILITY_CHANGED, this._isListVisible));
-    if (isListVisible) {
-      this.player.dispatchEvent(new KalturaPlayer.core.FakeEvent(RelatedEvent.RELATED_OPEN, {expandMode: this.config?.expandMode}));
-    } else {
-      this.player.dispatchEvent(new KalturaPlayer.core.FakeEvent(RelatedEvent.RELATED_CLOSE, {expandMode: this.config?.expandMode}));
+    if (userInteraction) {
+      this.dispatchEvent(new KalturaPlayer.core.FakeEvent(RelatedInternalEvent.LIST_VISIBILITY_CHANGED, this._isListVisible));
+      if (isListVisible) {
+        this.player.dispatchEvent(new KalturaPlayer.core.FakeEvent(RelatedEvent.RELATED_OPEN, {expandMode: this.config?.expandMode}));
+      } else {
+        this.player.dispatchEvent(new KalturaPlayer.core.FakeEvent(RelatedEvent.RELATED_CLOSE, {expandMode: this.config?.expandMode}));
+      }
     }
   }
 }

--- a/src/related.tsx
+++ b/src/related.tsx
@@ -194,7 +194,7 @@ class Related extends KalturaPlayer.core.BasePlugin {
       },
       onClick: () => {
         if (!relatedManager.isGridVisible) {
-          relatedManager.isListVisible = !relatedManager.isListVisible;
+          relatedManager.updateListVisibility(!relatedManager.isListVisible, true);
         }
       },
       component: () => {
@@ -280,7 +280,7 @@ class Related extends KalturaPlayer.core.BasePlugin {
     }
     this.componentDisposers = [];
 
-    this.relatedManager.isListVisible = false;
+    this.relatedManager.updateListVisibility(false);
     this.relatedManager.isGridVisible = false;
     this.relatedManager.isAutoContinueCancelled = false;
     this.iconId = -1;


### PR DESCRIPTION
### Description of the Changes

- Changed function 'set isListVisible' to function 'updateListVisibility'.
- Added a new boolean variable called 'userInteraction' with default value 'false'.
- The function 'updateListVisibility' gets 'userInteraction =  true' only in places where the user in fact
 clicked the button to close the related list.

[FEC-14031](https://kaltura.atlassian.net/browse/FEC-14031)


[FEC-14031]: https://kaltura.atlassian.net/browse/FEC-14031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ