### PR TITLE
fix(ADA-1736) - Add tooltip and tooltip strict position

### DIFF
--- a/src/components/list-toggle-button/list-toggle-button.tsx
+++ b/src/components/list-toggle-button/list-toggle-button.tsx
@@ -1,5 +1,5 @@
 const {withText} = KalturaPlayer.ui.preacti18n;
-const {Icon} = KalturaPlayer.ui.components;
+const {Tooltip, Icon} = KalturaPlayer.ui.components;
 import {Icon as IconPath} from 'types';
 
 import * as styles from './list-toggle-button.scss';
@@ -15,13 +15,15 @@ const ListToggleButton = withText({
   relatedVideosText: 'related.relatedVideos'
 })(({disabled, relatedVideosText}: {disabled: boolean; relatedVideosText: string}) => {
   return (
-    <button
-      aria-label={relatedVideosText}
-      tabIndex={0}
-      disabled={disabled}
-      className={`${styles.listToggleButton} ${KalturaPlayer.ui.style.upperBarIcon}`}>
-      <Icon id={`related-toggle-icon`} path={IconPath.LIST_TOGGLE} viewBox={`0 0 32 32`} />
-    </button>
+    <Tooltip label={relatedVideosText} type="bottom-left" strictPosition={true}>
+      <button
+        aria-label={relatedVideosText}
+        tabIndex={0}
+        disabled={disabled}
+        className={`${styles.listToggleButton} ${KalturaPlayer.ui.style.upperBarIcon}`}>
+        <Icon id={`related-toggle-icon`} path={IconPath.LIST_TOGGLE} viewBox={`0 0 32 32`} />
+      </button>
+    </Tooltip>
   );
 });
 


### PR DESCRIPTION
This solves https://kaltura.atlassian.net/browse/ADA-1736. 
I've added the missing tooltip.
It sets the Tooltip position to always be bottom-left.


### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
